### PR TITLE
Anonymous Can Now Post as Guest When They Select Anonymous. 

### DIFF
--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -34,8 +34,6 @@ define('composer', [
 		formatting: undefined,
 	};
 
-	var anonymous = false;
-
 	$(window).off('resize', onWindowResize).on('resize', onWindowResize);
 	onWindowResize();
 

--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -34,6 +34,8 @@ define('composer', [
 		formatting: undefined,
 	};
 
+	var anonymous = false;
+
 	$(window).off('resize', onWindowResize).on('resize', onWindowResize);
 	onWindowResize();
 
@@ -354,12 +356,25 @@ define('composer', [
 			composer.posts[post_uuid].modified = true;
 		});
 
+		// Handling anonymous checkbox state and setting anonymous attribute in composerData to true
 		postContainer.on('click', '.composer-submit', function (e) {
 			e.preventDefault();
 			e.stopPropagation();	// Other click events bring composer back to active state which is undesired on submit
 
 			$(this).attr('disabled', true);
+
+			// Checking if the anonymous checkbox is checked
+			var isAnonymousChecked = $('#toggleSwitch').is(':checked');
+			if (isAnonymousChecked){
+				composer.posts[post_uuid].isAnonymous = true;
+			}
+	
 			post(post_uuid);
+
+			// Reload page because the changes would not appear unless page is reloaded
+			setTimeout(function() {
+            window.location.reload();
+        	}, 10);		
 		});
 
 		require(['mousetrap'], function (mousetrap) {
@@ -710,6 +725,7 @@ define('composer', [
 		let method = 'post';
 		let route = '';
 
+		// Here, I add an anonymous attribute to the composerData in every form (post, reply, edit)
 		if (action === 'topics.post') {
 			route = '/topics';
 			composerData = {
@@ -721,6 +737,7 @@ define('composer', [
 				cid: categoryList.getSelectedCid(),
 				tags: tags.getTags(post_uuid),
 				timestamp: scheduler.getTimestamp(),
+				isAnonymous: composer.posts[post_uuid].isAnonymous,
 			};
 		} else if (action === 'posts.reply') {
 			route = `/topics/${postData.tid}`;
@@ -730,6 +747,7 @@ define('composer', [
 				handle: handleEl ? handleEl.val() : undefined,
 				content: bodyEl.val(),
 				toPid: postData.toPid,
+				isAnonymous: composer.posts[post_uuid].isAnonymous,
 			};
 		} else if (action === 'posts.edit') {
 			method = 'put';
@@ -743,6 +761,7 @@ define('composer', [
 				thumb: thumbEl.val() || '',
 				tags: tags.getTags(post_uuid),
 				timestamp: scheduler.getTimestamp(),
+				isAnonymous: composer.posts[post_uuid].isAnonymous,
 			};
 		}
 		var submitHookData = {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -14,6 +14,8 @@ const privileges = require('../privileges');
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
 		// This is an internal method, consider using Topics.reply instead
+
+		// Might be a good idea to do some testing here to see what happens, but we'll see
 		const { uid } = data;
 		const { tid } = data;
 		const content = data.content.toString();

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -117,6 +117,10 @@ module.exports = function (Topics) {
 			await user.isReadyToPost(uid, data.cid);
 		}
 
+		if (data.isAnonymous) {
+			data.uid = 0;
+		}
+
 		const tid = await Topics.create(data);
 
 		let postData = data;
@@ -191,6 +195,10 @@ module.exports = function (Topics) {
 		// For replies to scheduled topics, don't have a timestamp older than topic's itself
 		if (topicData.scheduled) {
 			data.timestamp = topicData.lastposttime + 1;
+		}
+
+		if (data.isAnonymous) {
+			data.uid = 0;
 		}
 
 		data.ip = data.req ? data.req.ip : null;

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -140,6 +140,8 @@ module.exports = function (Topics) {
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
 
+				// Trying to work on this file to try and customize anonymous more
+
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));


### PR DESCRIPTION
Implemented backend for Anonymous Posts where the user can post anonymously, however, they are displayed as 'Guest'.

- Modified `nodebb-plugin-composer-default/static/lib/composer.j` and `src/topics/create.js`
- Added a flag to detect when the user selects to post anonymously in composer.js
- Added an attribute to composerData in composer.js
- Added conditions in create.js to switch the user id of the user to 0 when anonymous is True

This enhancement allows the user to create a post anonymously which makes the user comfortable when posting.

Resolves Issue #37 