### PR TITLE
JSHint Tool Installation

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -76,6 +76,7 @@
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",
         "ipaddr.js": "2.2.0",
+        "jshint": "^2.13.6",
         "jquery": "3.7.1",
         "jquery-deserialize": "2.0.0",
         "jquery-form": "4.3.0",


### PR DESCRIPTION
**Description:**
Successfully installed the JSHint tool.

This tool is responsible for identifying potential issues in JavaScript code, enhancing code quality, and maintaining a consistent standard. JSHint was chosen to help catch common errors and improve code readability throughout the project.

The current verison installed is 2.13.6
<img width="563" alt="Screen Shot 2024-10-24 at 11 32 37 PM" src="https://github.com/user-attachments/assets/6bb3f743-7982-445b-bb45-2c9821a257f2">

**How to Use JSHint:**
To use the tool, the following commands can be run:

Lint Files:
jshint [YOUR FILE PATH]

**Files Edited:**
During installation this "jshint": "^2.13.6" was added to package.json. 
<img width="1133" alt="Screen Shot 2024-10-24 at 11 35 00 PM" src="https://github.com/user-attachments/assets/17b82a03-93ba-439b-b4db-8cc7216509f8">

Since these changes weren't initially tracked, I added this "jshint": "^2.13.6" to install/package.json to ensure it would be included in version control.
<img width="1130" alt="Screen Shot 2024-10-24 at 11 34 27 PM" src="https://github.com/user-attachments/assets/81106744-9b60-4f53-8b46-db6c06fac8c1">


**Testing:**
We ran JSHint on src/categories/watch.js and this was the output.
<img width="1008" alt="Screen Shot 2024-10-24 at 5 38 38 PM" src="https://github.com/user-attachments/assets/601c1cbd-3819-4a7d-8d51-d5086187e993">

This indicates that the tool was integrated and we were able to run it on our files.
